### PR TITLE
Update synth90k dataset url

### DIFF
--- a/data/download_synth90k.sh
+++ b/data/download_synth90k.sh
@@ -1,2 +1,2 @@
-wget http://www.robots.ox.ac.uk/~vgg/data/text/mjsynth.tar.gz
+wget https://thor.robots.ox.ac.uk/~vgg/data/text/mjsynth.tar.gz
 tar zxvf mjsynth.tar.gz


### PR DESCRIPTION
The old URL has been removed, so the update is necessary.