### PR TITLE
Fix bug: use blank in beam_search_decode

### DIFF
--- a/src/ctc_decoder.py
+++ b/src/ctc_decoder.py
@@ -54,7 +54,7 @@ def beam_search_decode(emission_log_prob, blank=0, **kwargs):
     # sum up beams to produce labels
     total_accu_log_prob = {}
     for prefix, accu_log_prob in beams:
-        labels = tuple(_reconstruct(prefix))
+        labels = tuple(_reconstruct(prefix, blank))
         # log(p1 + p2) = logsumexp([log_p1, log_p2])
         total_accu_log_prob[labels] = \
             logsumexp([accu_log_prob, total_accu_log_prob.get(labels, NINF)])


### PR DESCRIPTION
blank wasn't passed to _reconstruct in beam_search_decode